### PR TITLE
rm rpy2, as it is not needed for faimed3d

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@ nbdev==1.1.5
 scikit-image==0.17.2
 pydicom==2.0.0
 torch==1.7.0
-rpy2==2.9.4
 torchvision==0.8.1
 kornia==0.4.1
 simpleitk==2.0.2


### PR DESCRIPTION
rpy2 is listed as requirement, but not used. Removed rpy2 from `requirements.txt`